### PR TITLE
Correccion a tipo de Contraseña

### DIFF
--- a/economiaCompartida/src/java/model/Usuario.hbm.xml
+++ b/economiaCompartida/src/java/model/Usuario.hbm.xml
@@ -12,7 +12,7 @@
         <property name="nombre" type="string">
             <column name="nombre" not-null="true" />
         </property>
-        <property name="contrasena" type="int">
+        <property name="contrasena" type="string">
             <column name="contrasena" not-null="true" />
         </property>
         <property name="calificacion" type="java.lang.Integer">


### PR DESCRIPTION
Corregido el tipo de la columna "Contrasena" en el archivo
Usuario.hbm.xml
(Esto debido a que al re-hacer el mapeo objeto relacional, se quedaron
los tipos anteriores de las columnas hechas, a pesar de tener
actualizada la base de datos)
